### PR TITLE
Adiciona o provedor de sugestões de busca ao AndroidManifest e implem…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,21 +17,11 @@
             android:name=".BrevetelaActivity2"
             android:exported="false" />
 
-        <!-- Provider (mantido conforme seu código) -->
+        <!-- Provider de sugestões de busca -->
         <provider
-            android:authorities="com.example.xaamaai"
-            android:exported="true"
-            tools:ignore="MissingClass"
-            android:name="android.content.SearchRecentSuggestionsProvider">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.app.slice.category.SLICE" />
-                <data
-                    android:host="xaamaai.example.com"
-                    android:pathPrefix="/"
-                    android:scheme="http" />
-            </intent-filter>
-        </provider>
+            android:name=".MySuggestionProvider"
+            android:authorities="com.example.xaamaai.MySuggestionProvider"
+            android:exported="true" />
 
         <!-- Activity de cadastro -->
         <activity

--- a/app/src/main/java/com/example/xaamaai/MySuggestionProvider.java
+++ b/app/src/main/java/com/example/xaamaai/MySuggestionProvider.java
@@ -1,0 +1,12 @@
+package com.example.xaamaai;
+
+import android.content.SearchRecentSuggestionsProvider;
+
+public class MySuggestionProvider extends SearchRecentSuggestionsProvider {
+    public static final String AUTHORITY = "com.example.xaamaai.MySuggestionProvider";
+    public static final int MODE = DATABASE_MODE_QUERIES;
+
+    public MySuggestionProvider() {
+        setupSuggestions(AUTHORITY, MODE);
+    }
+}


### PR DESCRIPTION
…enta a classe MySuggestionProvider


nao deveria usar searchrecentsugestionsprovider direto no android manifest pq o provider é uma classe abstrata e precisa ser extendida por alguma outra pra poder usar, por isso criei a mysuggestion e joguei dentro do android manifest